### PR TITLE
fix: Ensure service cards have even heights

### DIFF
--- a/components/ServicesSection.tsx
+++ b/components/ServicesSection.tsx
@@ -64,9 +64,9 @@ export default function ServicesSection() {
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: index * 0.1 }}
               viewport={{ once: true }}
-              className="group"
+              className="group flex flex-col" // Added flex flex-col
             >
-              <div className="glass bg-gray-50/80 border border-gray-200/50 rounded-3xl p-8 hover:shadow-xl transition-all duration-300 group-hover:bg-white/90">
+              <div className="glass bg-gray-50/80 border border-gray-200/50 rounded-3xl p-8 hover:shadow-xl transition-all duration-300 group-hover:bg-white/90 h-full"> {/* Added h-full */}
                 <div className="w-16 h-16 bg-black rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
                   <service.icon className="w-8 h-8 text-white" />
                 </div>


### PR DESCRIPTION
Applied Tailwind CSS utility classes (`flex flex-col` and `h-full`) to the service card components to ensure they maintain a consistent height regardless of content length. This addresses the issue of unevenly sized cards in the services section.