### PR TITLE
feat: Add scroll-to-top button

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ export const metadata: Metadata = {
   description: 'We buy properties for cash fast as-is in NYC. No repairs, no agents, no hassle. Trusted property buyers since 1988. Get your cash offer today.',
 };
 
+import ScrollToTopButton from '@/components/ScrollToTopButton'; // Import the new component
+
 export default function RootLayout({
   children,
 }: {
@@ -13,7 +15,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className="overflow-x-hidden">{children}</body>
+      <body className="overflow-x-hidden">
+        {children}
+        <ScrollToTopButton /> {/* Add the button here */}
+      </body>
     </html>
   );
 }

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when page is scrolled down
+  const toggleVisibility = () => {
+    if (window.scrollY > 400) { // Threshold: 400px
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  // Set up event listener for scroll
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  // Scroll to top smoothly
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <>
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-5 right-5 z-50 p-3 bg-primary text-primary-foreground rounded-full shadow-md hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-opacity duration-300"
+          aria-label="Scroll to top"
+        >
+          {/* Using a simple SVG arrow icon. You can replace this with any icon library or text */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              fillRule="evenodd"
+              d="M11.47 2.47a.75.75 0 011.06 0l7.5 7.5a.75.75 0 11-1.06 1.06l-6.22-6.22V21a.75.75 0 01-1.5 0V4.81l-6.22 6.22a.75.75 0 01-1.06-1.06l7.5-7.5z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      )}
+    </>
+  );
+};
+
+export default ScrollToTopButton;


### PR DESCRIPTION
- Created a ScrollToTopButton component that appears after scrolling 400px.
- Styled the button using Tailwind CSS for fixed positioning and appearance.
- Integrated the button into the main layout to be available on all pages.