### PR TITLE
Fix: Improve responsive padding in contact section

### DIFF
--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -232,7 +232,7 @@ export default function ContactSection() {
         </div>
 
         <div id="contact-information-section" className="py-24 bg-gray-50">
-          <div className="max-w-7xl mx-auto px-32">
+          <div className="max-w-7xl mx-auto px-6 sm:px-8 md:px-16 lg:px-24 xl:px-32">
             <motion.div
               id="contact-details-area" // Added ID here
               initial={{ opacity: 0, y: 30 }}


### PR DESCRIPTION
The previous fixed padding (px-32) in the contact information section caused layout issues on mobile devices, making elements appear shrunken. This change replaces the fixed padding with responsive padding (px-6 sm:px-8 md:px-16 lg:px-24 xl:px-32) to ensure the layout adapts correctly to different screen sizes.